### PR TITLE
update default search limit and version

### DIFF
--- a/lib/outbrain/api/geo_location.rb
+++ b/lib/outbrain/api/geo_location.rb
@@ -3,7 +3,7 @@ module Outbrain
     class GeoLocation < Base
       PATH='locations/search'
 
-      def self.search(query, limit = 10)
+      def self.search(query, limit = 80)
         options = {term: query, limit: limit}
         Request.search(PATH, options, as: self)
       end

--- a/lib/outbrain/api/geo_location.rb
+++ b/lib/outbrain/api/geo_location.rb
@@ -3,8 +3,8 @@ module Outbrain
     class GeoLocation < Base
       PATH='locations/search'
 
-      def self.search(query, limit = 80)
-        options = {term: query, limit: limit}
+      def self.search(query, limit = 50, exclude = "PostalCode")
+        options = {term: query, limit: limit, exclude: exclude}
         Request.search(PATH, options, as: self)
       end
     end

--- a/lib/outbrain/api/version.rb
+++ b/lib/outbrain/api/version.rb
@@ -1,5 +1,5 @@
 module Outbrain
   module Api
-    VERSION = "0.2.8"
+    VERSION = "0.2.9"
   end
 end


### PR DESCRIPTION
This will relate to this pr https://github.com/simplereach/paid-webapp/pull/180 in paid web app and to run `bundle update` in skycutter to use the new _gem version 2.9_. 

Tests for skycutter written here: https://github.com/simplereach/skycutter/pull/1232
